### PR TITLE
Change sorting condition

### DIFF
--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -46,7 +46,7 @@
     #if $samout_conditional.samout:
         --samout=$__new_file_path__/${samoutfile.id}_tmp
     #end if
-    #if $force_sort:
+    #if not $force_sort:
         --order=name
         --format=bam
         name_sorted_alignment.bam

--- a/tools/htseq_count/htseq-count.xml
+++ b/tools/htseq_count/htseq-count.xml
@@ -1,4 +1,4 @@
-<tool id="htseq_count" name="htseq-count" version="0.6.1galaxy1">
+<tool id="htseq_count" name="htseq-count" version="0.6.1galaxy2">
     <description> - Count aligned reads in a BAM file that overlap features in a GFF file</description>
     <requirements>
         <requirement type="package" version="0.6.1">htseq</requirement>


### PR DESCRIPTION
@lparsons is it possible that we need to change the logic behind the sort option?
If we force the soring we need to set `--oder=pos` otherwise to `name` isn't it?

If so can you please update the wrapper?
